### PR TITLE
Add tests and docs for uv builder

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,11 @@ in the `PEP 518 <https://peps.python.org/pep-0518/>`_ standardized ``pyproject.t
 Jobs can be run on multiple Python versions at once, and independent steps can be
 executed in parallel for faster results.
 
+When installed, `thx` uses the `uv <https://github.com/astral-sh/uv>`_ package
+manager to create virtual environments and install dependencies. The default
+``builder`` setting will auto-detect ``uv`` and fall back to ``pip`` when
+necessary.
+
 Watch `thx` format the codebase, build sphinx docs, run the test and linter suites on
 five Python versions, and generate a final coverage report:
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -103,6 +103,15 @@ The following project-level options are supported in the ``[tool.thx]`` table:
     ``.gitignore`` will not trigger watch behavior, even if specified in
     :attr:`watch_paths`.
 
+.. attribute:: builder
+    :type: Literal['auto', 'pip', 'uv']
+    :value: auto
+
+    Selects the tool used to create and manage virtual environments. When set to
+    ``auto`` (the default), `thx` will prefer ``uv`` if it is available on the
+    system ``PATH`` and fall back to ``pip`` and the standard library ``venv``.
+    Set this to ``uv`` or ``pip`` to force a specific builder. If ``uv`` is
+    requested but not found, `thx` will raise :class:`ConfigError`.
 
 Jobs
 ----

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,9 @@
 .. include:: ../README.rst
     :start-after: Demo of thx in watch mode
 
+`thx` will use the `uv <https://github.com/astral-sh/uv>`_ package manager for
+creating virtual environments when it is available.
+
 .. toctree::
     :hidden:
     :maxdepth: 2

--- a/thx/context.py
+++ b/thx/context.py
@@ -169,6 +169,10 @@ def identify_venv(venv_path: Path) -> Tuple[Path, Version]:
         python_path = bin_dir / candidate
         if python_path.exists():
             break
+        if os.name == "nt":
+            python_path = python_path.with_suffix(".exe")
+            if python_path.exists():
+                break
     else:
         raise ConfigError(f"venv {venv_path} does not contain a Python interpreter")
     return python_path, version

--- a/thx/core.py
+++ b/thx/core.py
@@ -166,7 +166,7 @@ def run(
     return 0
 
 
-class ThxWatchdogHandler(FileSystemEventHandler):
+class ThxWatchdogHandler(FileSystemEventHandler):  # type: ignore[misc]
     EXCLUDES = [
         "__pycache__",
         ".git",

--- a/thx/core.py
+++ b/thx/core.py
@@ -166,7 +166,7 @@ def run(
     return 0
 
 
-class ThxWatchdogHandler(FileSystemEventHandler):  # type: ignore[misc]
+class ThxWatchdogHandler(FileSystemEventHandler):
     EXCLUDES = [
         "__pycache__",
         ".git",

--- a/thx/core.py
+++ b/thx/core.py
@@ -194,7 +194,7 @@ class ThxWatchdogHandler(FileSystemEventHandler):
         self.__excludes = gitignore(self.__root) + pathspec(self.EXCLUDES)
 
     def on_any_event(self, event: FileSystemEvent) -> None:
-        source_path = Path(event.src_path).resolve()
+        source_path = Path(str(event.src_path)).resolve()
 
         if source_path.is_dir():
             return
@@ -233,7 +233,7 @@ class ThxWatchdogHandler(FileSystemEventHandler):
             watch_paths = {config.root / "pyproject.toml"} | config.watch_paths
 
         for path in watch_paths:
-            observer.schedule(self, config.root / path, recursive=True)
+            observer.schedule(self, str(config.root / path), recursive=True)
 
     def signal(self, *args: Any) -> None:
         LOG.warning("ctrl-c")

--- a/thx/tests/context.py
+++ b/thx/tests/context.py
@@ -643,3 +643,20 @@ class ContextTest(TestCase):
                     ),
                 ]
             )
+
+    @patch("platform.system", return_value="Windows")
+    def test_identify_venv_windows(self, system_mock: Mock) -> None:
+        """identify_venv should locate python.exe on Windows."""
+        with TemporaryDirectory() as td:
+            tdp = Path(td)
+            venv = tdp / "venv"
+            bin_dir = venv / "Scripts"
+            bin_dir.mkdir(parents=True)
+            (venv / "pyvenv.cfg").write_text("version = 3.12\n")
+            exe = bin_dir / "python.exe"
+            exe.touch()
+
+            with patch("thx.context.os.name", "nt"):
+                python_path, version = context.identify_venv(venv)
+            self.assertEqual(exe, python_path)
+            self.assertEqual(Version("3.12"), version)

--- a/thx/tests/context.py
+++ b/thx/tests/context.py
@@ -18,6 +18,7 @@ from ..types import (
     Builder,
     CommandResult,
     Config,
+    ConfigError,
     Context,
     Event,
     Options,
@@ -506,3 +507,123 @@ class ContextTest(TestCase):
             for event in expected:
                 self.assertIn(event, events)
             venv_mock.assert_has_calls([call(ctx, config) for ctx in contexts])
+
+    @patch("thx.context.shutil.which", new=Mock(return_value="/usr/bin/uv"))
+    def test_determine_builder_auto_uv(self) -> None:
+        """Builder.AUTO should prefer uv when available."""
+        config = Config(builder=Builder.AUTO)
+        result = context.determine_builder(config)
+        self.assertEqual(Builder.UV, result)
+
+    @patch("thx.context.shutil.which", new=Mock(return_value=None))
+    def test_determine_builder_auto_no_uv(self) -> None:
+        """Builder.AUTO should fall back to pip when uv is missing."""
+        config = Config(builder=Builder.AUTO)
+        result = context.determine_builder(config)
+        self.assertEqual(Builder.PIP, result)
+
+    @patch("thx.context.shutil.which", new=Mock(return_value=None))
+    def test_determine_builder_uv_missing(self) -> None:
+        """Builder.UV should raise ConfigError if uv isn't installed."""
+        config = Config(builder=Builder.UV)
+        with self.assertRaises(ConfigError):
+            context.determine_builder(config)
+
+    @patch("thx.context.determine_builder", return_value=Builder.UV)
+    @patch("thx.context.find_runtime")
+    def test_resolve_contexts_uv(self, runtime_mock: Mock, det_mock: Mock) -> None:
+        """resolve_contexts should build uv contexts without runtime discovery."""
+        with TemporaryDirectory() as td:
+            tdp = Path(td).resolve()
+            versions = [Version("3.9"), Version("3.10")]
+            config = Config(root=tdp, versions=versions, builder=Builder.UV)
+            result = context.resolve_contexts(config, Options())
+            expected = [
+                Context(v, None, context.venv_path(config, v), Builder.UV)
+                for v in versions
+            ]
+            self.assertListEqual(expected, result)
+            runtime_mock.assert_not_called()
+
+    @patch("thx.context.determine_builder", return_value=Builder.UV)
+    @patch("thx.context.find_runtime")
+    def test_resolve_contexts_uv_filter(self, runtime_mock: Mock, det_mock: Mock) -> None:
+        """resolve_contexts should honor requested version filters with uv."""
+        with TemporaryDirectory() as td:
+            tdp = Path(td).resolve()
+            versions = [Version("3.9"), Version("3.10")]
+            config = Config(root=tdp, versions=versions, builder=Builder.UV)
+            result = context.resolve_contexts(
+                config, Options(python=Version("3.9"))
+            )
+            expected = [
+                Context(Version("3.9"), None, context.venv_path(config, Version("3.9")), Builder.UV)
+            ]
+            self.assertListEqual(expected, result)
+            runtime_mock.assert_not_called()
+
+    @patch("thx.context.check_command")
+    @patch("thx.context.identify_venv")
+    @patch("thx.context.shutil.which", new=Mock(return_value="/usr/bin/uv"))
+    @async_test
+    async def test_prepare_virtualenv_uv(
+        self,
+        identity_mock: Mock,
+        run_mock: Mock,
+    ) -> None:
+        """Virtualenv preparation via uv should call expected commands."""
+        async def fake_check_command(cmd: Sequence[StrPath], context: Optional[Context] = None) -> CommandResult:
+            return CommandResult(0, "", "")
+
+        run_mock.side_effect = fake_check_command
+
+        with TemporaryDirectory() as td:
+            tdp = Path(td).resolve()
+            req = tdp / "requirements.txt"
+            req.write_text("\n")
+
+            venv = tdp / ".thx" / "venv" / "3.9"
+            venv.mkdir(parents=True)
+
+            identity_mock.return_value = (
+                Path(venv / "bin/python"),
+                Version("3.9"),
+            )
+
+            config = Config(root=tdp, builder=Builder.UV, extras=["xtra"])
+            ctx = Context(Version("3.9"), None, venv, builder=Builder.UV)
+
+            events = [event async for event in context.prepare_virtualenv(ctx, config)]
+            expected = [
+                VenvCreate(ctx, "creating virtualenv"),
+                VenvCreate(ctx, "installing requirements via uv"),
+                VenvCreate(ctx, "installing project via uv"),
+                VenvReady(ctx),
+            ]
+            self.assertEqual(expected, events)
+
+            run_mock.assert_has_calls(
+                [
+                    call([
+                        "/usr/bin/uv",
+                        "venv",
+                        f"--prompt=thx-{ctx.python_version}",
+                        "-p",
+                        str(ctx.python_version),
+                        str(ctx.venv),
+                    ]),
+                    call([
+                        "/usr/bin/uv",
+                        "pip",
+                        "install",
+                        "-r",
+                        str(req),
+                    ], context=ctx),
+                    call([
+                        "/usr/bin/uv",
+                        "pip",
+                        "install",
+                        f"{config.root}[xtra]",
+                    ], context=ctx),
+                ]
+            )

--- a/thx/tests/context.py
+++ b/thx/tests/context.py
@@ -547,17 +547,22 @@ class ContextTest(TestCase):
 
     @patch("thx.context.determine_builder", return_value=Builder.UV)
     @patch("thx.context.find_runtime")
-    def test_resolve_contexts_uv_filter(self, runtime_mock: Mock, det_mock: Mock) -> None:
+    def test_resolve_contexts_uv_filter(
+        self, runtime_mock: Mock, det_mock: Mock
+    ) -> None:
         """resolve_contexts should honor requested version filters with uv."""
         with TemporaryDirectory() as td:
             tdp = Path(td).resolve()
             versions = [Version("3.9"), Version("3.10")]
             config = Config(root=tdp, versions=versions, builder=Builder.UV)
-            result = context.resolve_contexts(
-                config, Options(python=Version("3.9"))
-            )
+            result = context.resolve_contexts(config, Options(python=Version("3.9")))
             expected = [
-                Context(Version("3.9"), None, context.venv_path(config, Version("3.9")), Builder.UV)
+                Context(
+                    Version("3.9"),
+                    None,
+                    context.venv_path(config, Version("3.9")),
+                    Builder.UV,
+                )
             ]
             self.assertListEqual(expected, result)
             runtime_mock.assert_not_called()
@@ -572,7 +577,10 @@ class ContextTest(TestCase):
         run_mock: Mock,
     ) -> None:
         """Virtualenv preparation via uv should call expected commands."""
-        async def fake_check_command(cmd: Sequence[StrPath], context: Optional[Context] = None) -> CommandResult:
+
+        async def fake_check_command(
+            cmd: Sequence[StrPath], context: Optional[Context] = None
+        ) -> CommandResult:
             return CommandResult(0, "", "")
 
         run_mock.side_effect = fake_check_command
@@ -604,26 +612,34 @@ class ContextTest(TestCase):
 
             run_mock.assert_has_calls(
                 [
-                    call([
-                        "/usr/bin/uv",
-                        "venv",
-                        f"--prompt=thx-{ctx.python_version}",
-                        "-p",
-                        str(ctx.python_version),
-                        str(ctx.venv),
-                    ]),
-                    call([
-                        "/usr/bin/uv",
-                        "pip",
-                        "install",
-                        "-r",
-                        str(req),
-                    ], context=ctx),
-                    call([
-                        "/usr/bin/uv",
-                        "pip",
-                        "install",
-                        f"{config.root}[xtra]",
-                    ], context=ctx),
+                    call(
+                        [
+                            "/usr/bin/uv",
+                            "venv",
+                            f"--prompt=thx-{ctx.python_version}",
+                            "-p",
+                            str(ctx.python_version),
+                            str(ctx.venv),
+                        ]
+                    ),
+                    call(
+                        [
+                            "/usr/bin/uv",
+                            "pip",
+                            "install",
+                            "-r",
+                            str(req),
+                        ],
+                        context=ctx,
+                    ),
+                    call(
+                        [
+                            "/usr/bin/uv",
+                            "pip",
+                            "install",
+                            f"{config.root}[xtra]",
+                        ],
+                        context=ctx,
+                    ),
                 ]
             )

--- a/thx/utils.py
+++ b/thx/utils.py
@@ -105,8 +105,6 @@ class timed:
 
 
 def get_timings() -> List[timed]:
-    global TIMINGS
-
     result = list(sorted(TIMINGS))
     TIMINGS.clear()
     return result


### PR DESCRIPTION
## Summary
- add uv builder docs
- test uv builder paths and context resolution
- document builder option values
- add docstrings and preconfigure mocks
- mention uv usage in README and docs intro
- fix mypy path warnings

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6843f9a3c7f08328b4e72d720eb6546f