### PR TITLE
Cache uv lookup

### DIFF
--- a/thx/context.py
+++ b/thx/context.py
@@ -30,7 +30,7 @@ from .types import (
     VenvReady,
     Version,
 )
-from .utils import timed, venv_bin_path, version_match, which
+from .utils import locate_uv, timed, venv_bin_path, version_match, which
 
 LOG = logging.getLogger(__name__)
 PYTHON_VERSION_RE = re.compile(r"Python (\d+\.\d+[a-zA-Z0-9-_.]+)\+?")
@@ -318,7 +318,7 @@ def determine_builder(config: Config) -> Builder:
 
     If builder is auto, pick uv if available, else pip.
     """
-    uv = shutil.which("uv")
+    uv = locate_uv()
     if config.builder == Builder.AUTO:
         if uv is not None:
             return Builder.UV
@@ -410,7 +410,7 @@ async def prepare_virtualenv_uv(
     """Create and populate a venv using uv."""
     try:
         # Create the venv with uv
-        uv = shutil.which("uv")
+        uv = locate_uv()
         if not uv:
             raise ConfigError("uv not found on PATH, cannot build with uv")
 

--- a/thx/tests/context.py
+++ b/thx/tests/context.py
@@ -508,21 +508,21 @@ class ContextTest(TestCase):
                 self.assertIn(event, events)
             venv_mock.assert_has_calls([call(ctx, config) for ctx in contexts])
 
-    @patch("thx.context.shutil.which", new=Mock(return_value="/usr/bin/uv"))
+    @patch("thx.context.locate_uv", new=Mock(return_value="/usr/bin/uv"))
     def test_determine_builder_auto_uv(self) -> None:
         """Builder.AUTO should prefer uv when available."""
         config = Config(builder=Builder.AUTO)
         result = context.determine_builder(config)
         self.assertEqual(Builder.UV, result)
 
-    @patch("thx.context.shutil.which", new=Mock(return_value=None))
+    @patch("thx.context.locate_uv", new=Mock(return_value=None))
     def test_determine_builder_auto_no_uv(self) -> None:
         """Builder.AUTO should fall back to pip when uv is missing."""
         config = Config(builder=Builder.AUTO)
         result = context.determine_builder(config)
         self.assertEqual(Builder.PIP, result)
 
-    @patch("thx.context.shutil.which", new=Mock(return_value=None))
+    @patch("thx.context.locate_uv", new=Mock(return_value=None))
     def test_determine_builder_uv_missing(self) -> None:
         """Builder.UV should raise ConfigError if uv isn't installed."""
         config = Config(builder=Builder.UV)
@@ -569,7 +569,7 @@ class ContextTest(TestCase):
 
     @patch("thx.context.check_command")
     @patch("thx.context.identify_venv")
-    @patch("thx.context.shutil.which", new=Mock(return_value="/usr/bin/uv"))
+    @patch("thx.context.locate_uv", new=Mock(return_value="/usr/bin/uv"))
     @async_test
     async def test_prepare_virtualenv_uv(
         self,

--- a/thx/utils.py
+++ b/thx/utils.py
@@ -6,7 +6,7 @@ import platform
 import shutil
 from asyncio import iscoroutinefunction
 from dataclasses import dataclass, field, replace
-from functools import wraps
+from functools import lru_cache, wraps
 from itertools import zip_longest
 from pathlib import Path
 from time import monotonic_ns
@@ -126,6 +126,13 @@ def which(name: str, context: Context) -> str:
         if binary is None:
             return name
     return binary
+
+
+@lru_cache(maxsize=1)
+def locate_uv() -> Optional[str]:
+    """Locate the ``uv`` executable, if available."""
+
+    return shutil.which("uv")
 
 
 def version_match(versions: Iterable[Version], target: Version) -> List[Version]:


### PR DESCRIPTION
## Summary
- factor out `locate_uv()` to memoize calls to `shutil.which("uv")`
- use `locate_uv()` within context
- update tests for new helper

## Testing
- `pip install -e .[dev,docs]`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68494f5908608328abb4fd4bdaa7ed9f