### PR TITLE
Use existing config in watchdog reload

### DIFF
--- a/thx/core.py
+++ b/thx/core.py
@@ -218,7 +218,7 @@ class ThxWatchdogHandler(FileSystemEventHandler):
         new_config = reload_config(old_config)
         if new_config != old_config:
             LOG.info("Config change detected")
-            self.__options.config = reload_config(self.__options.config)
+            self.__options.config = new_config
             self.__resolve = True
             self.schedule()
 


### PR DESCRIPTION
## Summary
- simplify ThxWatchdogHandler.reload to use the already computed config instead of reloading again

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a890098c10832887dfc1567073ee60