### PR TITLE
docs: fix typo in extras description

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -76,7 +76,7 @@ The following project-level options are supported in the ``[tool.thx]`` table:
 .. attribute:: extras
     :type: list[str]
 
-    This specifies a list of package "extras" or optional dpendendencies to be
+    This specifies a list of package "extras" or optional dependencies to be
     installed when initializing virtual environments and installing the project.
 
 .. attribute:: python_versions


### PR DESCRIPTION
## Summary
- fix spelling error for extras description in config documentation

## Testing
- `make lint`
- `make test`
- `sphinx-build -b html docs html`


------
https://chatgpt.com/codex/tasks/task_e_68a8900a66cc8328942d28cb3b54a7bc